### PR TITLE
Update to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build Blinky firmware
       run: npx --package mini-cross@0.15.2 mc --no-tty firmware make -C firmware FIRMWARE=Blinky


### PR DESCRIPTION
Should avoid the warning caused by actions/checkout@v2

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2